### PR TITLE
Fix rounding in indexToXY

### DIFF
--- a/grids/grid.js
+++ b/grids/grid.js
@@ -35,7 +35,7 @@ class Grid {
     // index in cells to x y coordinate.
     indexToXY(index) {
       const x = index % this.width;
-      const y = index / this.width;
+      const y = Math.floor(index / this.width);
       return [x, y]
     }
   


### PR DESCRIPTION
## Summary
- update `indexToXY` to use `Math.floor` when converting from index to y coordinate

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68438c0b0a848329a960bac3ca94eab8