### PR TITLE
Fix typo in car comments

### DIFF
--- a/old/car.js
+++ b/old/car.js
@@ -69,7 +69,7 @@ class Car {
 
         // Max and min turning radii
         this.maxR = 2000 * carScale; // Max turning radius // can be too high and ineffective. 
-        // this basically deturmines how "sporty" the steering is on more straight angles
+        // this basically determines how "sporty" the steering is on more straight angles
         this.minR = this.carS[1] * 1.2; // Min turning radius is a little more then one car length
 
         // Car speeds

--- a/sketch.js
+++ b/sketch.js
@@ -1688,7 +1688,7 @@ const RoadType = {
 		this.off = 15 * carScale;
 		// Max and min turning radii
 		this.maxR = 2000 * carScale; // Max turning radius // can be too high and ineffective. 
-		// this basically deturmines how "sporty" the steering is on more straight angles
+                // this basically determines how "sporty" the steering is on more straight angles
 		this.minR = this.carS[1] * 1.2; // Min turning radius is a little more then one car length
 		// Car speeds
 		this.speed = 0;


### PR DESCRIPTION
## Summary
- fix a misspelling in steering comment in `sketch.js`
- fix the same typo in `old/car.js`

## Testing
- `grep -n "determines" -n old/car.js`
- `grep -n "determines" -n sketch.js`


------
https://chatgpt.com/codex/tasks/task_e_68438c102f308329887ffe9cfe41c241