### PR TITLE
Rename break method to brake

### DIFF
--- a/old/brain.js
+++ b/old/brain.js
@@ -627,7 +627,7 @@ class ABrain {
 
         if (trigger > 0.5) {
             if (debugBrain) console.log(" Break  :  ")
-            agentObj.break();
+            agentObj.brake();
         }
 
         if (agentObj.Selected) {

--- a/old/car.js
+++ b/old/car.js
@@ -165,7 +165,7 @@ class Car {
 
     }
 
-    break() {
+    brake() {
         if (abs(this.acceleration) >= 0) {
             this.acceleration -= this.acceleration * 0.08;
         }

--- a/old/sketch.js
+++ b/old/sketch.js
@@ -532,7 +532,7 @@ function draw() {
         }
 
         if (keyIsDown(SHIFT)) {
-            ccar.break();
+            ccar.brake();
         }
 
         // ccar.runBrain();

--- a/sketch.js
+++ b/sketch.js
@@ -1441,7 +1441,7 @@ class ABrain {
 
         if (trigger > 0.5) {
             if (debugBrain) console.log(" Break  :  ")
-            agentObj.break();
+            agentObj.brake();
         }
 
         if (agentObj.Selected) {
@@ -1770,12 +1770,12 @@ const RoadType = {
 			}
 		}
 		
-		break() {
-			if (abs(this.acceleration) >= 0) {
-				this.acceleration -= this.acceleration * 0.08;
-			}
-			this.breaking = true;
-		}
+                brake() {
+                        if (abs(this.acceleration) >= 0) {
+                                this.acceleration -= this.acceleration * 0.08;
+                        }
+                        this.breaking = true;
+                }
 		
 		runBrain() {
 			if (this.Selected) {


### PR DESCRIPTION
## Summary
- rename `break()` method in `Car` class to `brake()`
- update all calls to use `brake()`

## Testing
- `node --check sketch.js`
- `node --check old/car.js`
- `node --check old/brain.js`
- `node --check old/sketch.js`


------
https://chatgpt.com/codex/tasks/task_e_68438c70ce308329b2c5c603bfd19a96